### PR TITLE
Properly handle division by zero

### DIFF
--- a/expr/parser.py
+++ b/expr/parser.py
@@ -254,8 +254,8 @@ class Parser(metaclass=ParserMeta):
         except (ZeroDivisionError, _ZeroDivision):
             raise DivisionByZero()
 
-        except InvalidOperation as e:
-            if isinstance(e.args[0][0], DivisionUndefined):
+        except InvalidOperation as exc:
+            if isinstance(exc.args[0][0], DivisionUndefined):
                 raise DivisionByZero()
             raise BadOperation("Invalid Operation")
 

--- a/expr/parser.py
+++ b/expr/parser.py
@@ -2,7 +2,7 @@ import math
 
 from functools import wraps
 from warnings import catch_warnings, simplefilter
-from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation
+from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation, DivisionUndefined
 
 from rply import ParserGenerator, Token as _Token
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
@@ -88,7 +88,8 @@ class Parser(metaclass=ParserMeta):
     ) -> None:
         if not issubclass(decimal_cls, Decimal):
             raise TypeError('decimal_cls must inherit from decimal.Decimal')
-
+        
+        decimal.getcontext().traps[DivisionByZero] = True
         _ = decimal_cls
         self._max_safe_number: DT = _(max_safe_number)
         self._max_exponent: DT = _(max_exponent)
@@ -250,8 +251,13 @@ class Parser(metaclass=ParserMeta):
             if result is not None:
                 return cls(result.eval())
 
-        except (ZeroDivisionError, _ZeroDivision, InvalidOperation):
+        except (ZeroDivisionError, _ZeroDivision):
             raise DivisionByZero()
+
+        except InvalidOperation as e:
+            if isinstance(e.args[0][0], DivisionUndefined):
+                raise DivisionByZero()
+            raise BadOperation("Invalid Operation")
 
         except LexingError as exc:
             raise Gibberish(exc)

--- a/expr/parser.py
+++ b/expr/parser.py
@@ -2,7 +2,7 @@ import math
 
 from functools import wraps
 from warnings import catch_warnings, simplefilter
-from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation, DivisionUndefined, getcontext
+from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation, DivisionUndefined
 
 from rply import ParserGenerator, Token as _Token
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
@@ -28,6 +28,8 @@ __all__: Tuple[str, ...] = (
     'ParserMeta',
     'Parser'
 )
+    
+decimal.getcontext().traps[_ZeroDivision] = True
 
 
 def rule(pattern: str, /, precedence: Optional[str] = None) -> Callable[Callable[PT, RT], Callable[PT, RT]]:
@@ -89,7 +91,6 @@ class Parser(metaclass=ParserMeta):
         if not issubclass(decimal_cls, Decimal):
             raise TypeError('decimal_cls must inherit from decimal.Decimal')
         
-        getcontext().traps[_ZeroDivision] = True
         _ = decimal_cls
         self._max_safe_number: DT = _(max_safe_number)
         self._max_exponent: DT = _(max_exponent)
@@ -257,7 +258,7 @@ class Parser(metaclass=ParserMeta):
         except InvalidOperation as exc:
             if isinstance(exc.args[0][0], DivisionUndefined):
                 raise DivisionByZero()
-            raise BadOperation("Invalid Operation")
+            raise InvalidAction()
 
         except LexingError as exc:
             raise Gibberish(exc)

--- a/expr/parser.py
+++ b/expr/parser.py
@@ -2,7 +2,7 @@ import math
 
 from functools import wraps
 from warnings import catch_warnings, simplefilter
-from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation, DivisionUndefined
+from decimal import Decimal, DivisionByZero as _ZeroDivision, InvalidOperation, DivisionUndefined, getcontext
 
 from rply import ParserGenerator, Token as _Token
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
@@ -89,7 +89,7 @@ class Parser(metaclass=ParserMeta):
         if not issubclass(decimal_cls, Decimal):
             raise TypeError('decimal_cls must inherit from decimal.Decimal')
         
-        decimal.getcontext().traps[_ZeroDivision] = True
+        getcontext().traps[_ZeroDivision] = True
         _ = decimal_cls
         self._max_safe_number: DT = _(max_safe_number)
         self._max_exponent: DT = _(max_exponent)

--- a/expr/parser.py
+++ b/expr/parser.py
@@ -89,7 +89,7 @@ class Parser(metaclass=ParserMeta):
         if not issubclass(decimal_cls, Decimal):
             raise TypeError('decimal_cls must inherit from decimal.Decimal')
         
-        decimal.getcontext().traps[DivisionByZero] = True
+        decimal.getcontext().traps[_ZeroDivision] = True
         _ = decimal_cls
         self._max_safe_number: DT = _(max_safe_number)
         self._max_exponent: DT = _(max_exponent)


### PR DESCRIPTION
We need to handle 0/0 in InvalidOperation because it is not mathematically defined.

:rooBless:
![rooBless](https://user-images.githubusercontent.com/64497526/124395315-47b3f000-dcb8-11eb-8284-a044f438eec4.png)
